### PR TITLE
Ignore dot files

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -69,4 +69,5 @@ process.on('exit', function (code) {
     }
 });
 
-function jsFile (x) { return /\.js$/i.test(x) }
+function jsFile (x) { return /^[^\.]*\.js$/i.test(x) }
+


### PR DESCRIPTION
This should stop it from running with dot files. The goal is to ignore editor files like those produced by vim and emacs