### PR TITLE
add --no-stack option to command line

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -16,11 +16,11 @@ var regexTester = require('safe-regex-test');
 var jsFile = regexTester(/\.js$/i);
 
 var argv = minimist(process.argv.slice(2));
-var tap = faucet({
-	width: defined(argv.w, argv.width, process.stdout.isTTY
-		? process.stdout.columns - 5
-		: 0)
-});
+var opts = {
+	width: defined(argv.w, argv.width, process.stdout.isTTY ? process.stdout.columns - 5 : 0),
+	stack: defined(argv.stack, process.env.SHOW_STACK ? process.env.SHOW_STACK === 'true' : true)
+};
+var tap = faucet(opts);
 process.on('exit', function (code) {
 	if (code === 0 && tap.exitCode !== 0) {
 		process.exit(tap.exitCode);

--- a/index.js
+++ b/index.js
@@ -79,7 +79,9 @@ module.exports = function (opts) {
 			test.ok = false;
 		}
 		push(out, str);
-		push(test.assertions, res);
+		if (opts.stack) {
+			push(test.assertions, res);
+		}
 	});
 
 	tap.on('extra', function (extra) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -135,9 +135,10 @@ Once you've got a way to get TAP out of your tests, just pipe into `faucet`:
 
 ```
 usage:
-  faucet [FILES]
+  faucet [FILES] [--no-stack]
   command | faucet
 ```
+* the optional ```--no-stack``` argument will remove stack traces from failed test reports
 
 # license
 


### PR DESCRIPTION
Command line option to enable even more concise output by **not** including stack traces in output. 
e.g.:
```bash
faucet *.test --no-stack
X example
  not ok 3 fail test 1
  not ok 4 fail test 2
# tests 4
# pass  2
# fail  2  
```