### PR TITLE
Trim too long assert messages to prevent line overflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,10 @@ module.exports = function (opts) {
 	var tap = parser();
 	var out = through2();
 
-	function trimWidth(s) {
+	function trimWidth(s, ok) {
 		if (opts && opts.width && s.length > opts.width - 2) {
-			return s.slice(0, opts.width - 5) + '...';
+			var more = ok ? 0 : 4;
+			return s.slice(0, opts.width - 5 - more) + '...';
 		}
 		return s;
 	}
@@ -61,13 +62,13 @@ module.exports = function (opts) {
 			var s = trimWidth(trim(res.name));
 			push(out, sprintf(
 				'\x1b[1m\x1b[' + c + 'm%s\x1b[0m\n',
-				trimWidth((res.ok ? '✓' : '⨯') + ' ' + s)
+				trimWidth((res.ok ? '✓' : '⨯') + ' ' + s, res.ok)
 			));
 			return;
 		}
 
 		var fmt = '\r  %s \x1b[1m\x1b[' + c + 'm%d\x1b[0m %s\x1b[K';
-		var str = sprintf(fmt, ok, res.number, res.name);
+		var str = sprintf(fmt, ok, res.number, trimWidth(res.name, res.ok));
 
 		if (!res.ok) {
 			var y = ++test.offset + 1;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
 	},
 	"scripts": {
 		"lint": "eslint --ext=js,mjs .",
-		"pretest": "npm run lint"
+		"pretest": "npm run lint",
+		"tests-only": "tape test/**/*.js | node bin/cmd",
+		"test": "npm run tests-only"
 	},
 	"dependencies": {
 		"array.prototype.foreach": "^1.0.2",

--- a/test/long-message/failed.tap
+++ b/test/long-message/failed.tap
@@ -1,0 +1,20 @@
+TAP version 13
+# Resolving an unknown dependency fails.
+not ok 1 The message "Unrecognised dependency: "dummy"." should start with "Unrecognised dependency:".
+  ---
+    operator: ok
+    expected: true
+    actual:   false
+    at: Test.<anonymous> (/Users/ferdipr/Sources.localized/smartui/gitlab/csui-dependency-installer/test/dependencies.test.js:20:12)
+    stack: |-
+      Error: The message "Unrecognised dependency: "dummy"." should start with "Unrecognised dependency:".
+          at Test.bound [as run] (/Users/ferdipr/Sources/csui-dependency-installer/node_modules/tape/lib/test.js:77:32)
+          at Immediate.next (/Users/ferdipr/Sources/csui-dependency-installer/node_modules/tape/lib/results.js:81:19)
+          at runCallback (timers.js:810:20)
+  ...
+
+1..1
+# tests 1
+# pass  0
+# fail  1
+

--- a/test/long-message/index.js
+++ b/test/long-message/index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var test = require('tape');
+var stream = require('stream');
+var path = require('path');
+var fs = require('fs');
+var faucet = require('../..');
+
+function createFormatter() {
+	return faucet({ width: 80 });
+}
+
+function streamifyString(string) {
+	return new stream.Readable({
+		read: function () {
+			this.push(string);
+			this.push(null);
+		}
+	});
+}
+
+function stringifyStream(theStream, callback) {
+	var output = '';
+	theStream.on('data', function (chunk) {
+		output += chunk;
+	}).on('end', function () {
+		callback(output);
+	});
+}
+
+function getFilePath(name) {
+	return path.join(__dirname, name + '.tap');
+}
+
+function checkFormatting(t, name, expectedExcerpt) {
+	var tapString = fs.readFileSync(getFilePath(name), 'utf-8');
+	var formattedStream = streamifyString(tapString).pipe(createFormatter());
+	stringifyStream(formattedStream, function (actualOutput) {
+		var contains = actualOutput.indexOf(expectedExcerpt) > 0;
+
+		t.ok(contains, 'Looking for "' + expectedExcerpt + '" in the "' + name + '" input.');
+
+		t.end();
+	});
+}
+
+test('A long successful assertion message should be cut.', function (t) {
+	checkFormatting(t, 'succeeded', 'should start with "Unrecogn...');
+});
+
+test('A long failed assertion message should be cut.', function (t) {
+	checkFormatting(t, 'failed', 'should start with "Unre...');
+});

--- a/test/long-message/succeeded.tap
+++ b/test/long-message/succeeded.tap
@@ -1,0 +1,13 @@
+TAP version 13
+# Exported dependency names can be resolved.
+ok 1 The dependency "csui" should be resolvable.
+ok 2 The dependency "esoc" should be resolvable.
+# Resolving an unknown dependency fails.
+ok 3 The message "Unrecognised dependency: "dummy"." should start with "Unrecognised dependency:".
+
+1..3
+# tests 3
+# pass  3
+
+# ok
+


### PR DESCRIPTION
Attempts to fix #30.

Print this:

```txt
✓ Exported dependency names can be resolved.
✓ Resolving an unknown dependency fails.
# pass  3
✓ ok
```

instead of this:

```txt
✓ Exported dependency names can be resolved.
# Resolving an unknown dependency fails.
✓ Resolving an unknown dependency fails.ncy: "dummy"." should start with "Unre# tests 3
# pass  3
✓ ok
```

Fixes #30.